### PR TITLE
trigger workflow with label

### DIFF
--- a/.github/workflows/trigger-in-pr.yml
+++ b/.github/workflows/trigger-in-pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   demonstrate:
-    name: Demonstrate
+    name: Demonstrate triggering workflow
     if: github.event.label.name == 'deploy to lab'
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
In order to trigger an example workflow add the 'deploy to lab' label to this PR.